### PR TITLE
Add 'action' key to oauth callback endpoint json output

### DIFF
--- a/src/blueprints/mobile.py
+++ b/src/blueprints/mobile.py
@@ -29,22 +29,27 @@ def auth_callback():
     session['oauth_state'] = None
 
     user, jwt = complete_oauth(request.url, state)
-    output = {
+    msg = json_as_text({
         'action': 'loginSuccess',
         'user': user,
         'jwt': jwt
-    }
-    json = jsonify(output).get_data(as_text=True)
+    })
+    loading_msg = json_as_text({'action': 'loading'})
 
     # This javascript snippet will render in the oauth webview within the app
     # It sends the auth info to the app via the webview message interface
     return (
         f"""
         <script>
-            window.ReactNativeWebView.postMessage(JSON.stringify({json}))
+            window.ReactNativeWebView.postMessage(JSON.stringify({loading_msg}));
+            window.ReactNativeWebView.postMessage(JSON.stringify({msg}));
         </script>
         """
     )
+
+
+def json_as_text(data: dict) -> str:
+    return jsonify(data).get_data(as_text=True)
 
 
 @mobile.route('/requests', methods=['POST'])

--- a/src/blueprints/mobile.py
+++ b/src/blueprints/mobile.py
@@ -29,11 +29,12 @@ def auth_callback():
     session['oauth_state'] = None
 
     user, jwt = complete_oauth(request.url, state)
-    auth_data = {
+    output = {
+        'action': 'loginSuccess',
         'user': user,
         'jwt': jwt
     }
-    json = jsonify(auth_data).get_data(as_text=True)
+    json = jsonify(output).get_data(as_text=True)
 
     # This javascript snippet will render in the oauth webview within the app
     # It sends the auth info to the app via the webview message interface


### PR DESCRIPTION
Message handler in app expects the callback page json object to contain an 'action' key with 'loginSuccess' (see OauthWebViewScreen in seeus-dev/seeus-app#36)